### PR TITLE
perf: use telligro scoped puppeteer than github uri

### DIFF
--- a/packages/puppeteer-page-object-finder/finder.plugin.svc.js
+++ b/packages/puppeteer-page-object-finder/finder.plugin.svc.js
@@ -19,7 +19,7 @@
 
 'use strict';
 const path = require('path');
-const puppeteer = require('puppeteer');
+const puppeteer = require('@telligro/puppeteer');
 const check = require('check-types');
 const VError = require('verror');
 const nopt = require('nopt');

--- a/packages/puppeteer-page-object-finder/package.json
+++ b/packages/puppeteer-page-object-finder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telligro/opal-page-object-finder",
-  "version": "0.3.3",
+  "version": "0.3.6",
   "description": "Page Objects Finder app for inspecting web pages in chrome",
   "repository": {
     "type": "git",


### PR DESCRIPTION
using a published dependency instead of referencing a github uri significantly reduced the installation time